### PR TITLE
Add support for Sense Keypad

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,13 +252,15 @@ After flashing firmware from the [Sense Hub](https://wyze.com/home-security-syst
 'FFFFFFFF':
   class: alarm_control_panel
   pin: '0000'
+  expose_pin: false
   arm_required: true
   disarm_required: true
   invert_state: false
   name: Front Door Keypad
 ```
 
-- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Setting this to `"REMOTE_CODE"` will allow Home Assistant (when configured for discovery) to accept any PIN.
-- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad
-- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad
-- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors
+- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Can also be a list of PIN strings, which will be validated against.
+- `expose_pin` can be either `true` or `false`. If `true`, a `sensor` entity will be exposed to MQTT discovery which contains the most recent PIN entered. The same PIN will also be saved in the MQTT broker.
+- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad.
+- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad.
+- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors.

--- a/readme.md
+++ b/readme.md
@@ -250,13 +250,17 @@ Home Assistant simply needs to be configured with the MQTT broker that the gatew
 After flashing firmware from the [Sense Hub](https://wyze.com/home-security-system-sensors.html) to the original Sensor Bridge, this project can now support the [Sense Keypad](https://wyze.com/wyze-sense-keypad.html) as well! This entails either [dumping firmware from your own Hub](https://github.com/HclX/WyzeHacks/issues/111#issuecomment-824558304) or using firmware that has already been dumped, and then flashing it. Using the [WyzeSenseUpgrade](https://github.com/AK5nowman/WyzeSense) project is recommended, but is considered "use at your own risk". When a keypad is paired with WyzeSense2MQTT, it will send auto-discovery topics which allow control and statuses from within Home Assistant. The entry in `sensors.yaml` for the keypad looks like the following:
 ```yaml
 'FFFFFFFF':
+  name: Front Door Keypad
   class: alarm_control_panel
   pin: '0000'
   expose_pin: false
   arm_required: true
   disarm_required: true
   invert_state: false
-  name: Front Door Keypad
+  delay_time: 60
+  arming_time: 60
+  trigger_time: 120
+  disarm_after_trigger: False
 ```
 
 - `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Can also be a list of PIN strings, which will be validated against.
@@ -264,3 +268,34 @@ After flashing firmware from the [Sense Hub](https://wyze.com/home-security-syst
 - `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad.
 - `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad.
 - `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors.
+- `delay_time` must be an integer representing the number of seconds for the `pending` state to last before changing to `triggered`.
+- `arming_time` must be an integer representing the number of seconds for the `arming` state to last before changing to an 'armed' state (either `armed_home` or `armed_away`).
+- `trigger_time` must be an integer representing the number of seconds for the `triggered` state to last before finishing.
+- `disarm_after_trigger` can be either `true` or `false`. If `true`, the keypad will change to `disarmed` after the `triggered` state. If `false`, it will return to the previous state.
+
+A detailed explanation of the relationship between `delay_time`, `arming_time`, `trigger_time`, and `disarm_after_trigger` can be found in the [Home Assistant documentation](https://www.home-assistant.io/integrations/manual/#state-machine). Each of the time options can optionally be configured individually for each 'armed' state.
+
+For example, in this configuration:
+- `disarmed` will never trigger the alarm
+- `armed_home` will be set with no delay
+- `armed_away` will give 30 seconds after arming, and 20 seconds to disarm before triggering the alarm
+- When triggered, the alarm will last for 4 seconds
+```yaml
+'ABABABAB':
+  name: Entryway Keypad
+  class: alarm_control_panel
+  pin: '0000'
+  expose_pin: false
+  arm_required: true
+  disarm_required: true
+  invert_state: false
+  delay_time: 20
+  arming_time: 30
+  trigger_time: 4
+  disarmed:
+    trigger_time: 0
+  armed_home:
+    arming_time: 0
+    delay_time: 0
+  disarm_after_trigger: false
+```

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Configurable WyzeSense to MQTT Gateway intended for use with Home Assistant or o
     - [Removing a Sensor](#removing-a-sensor)
     - [Reload Sensors](#reload-sensors)
     - [Command Line Tool](#command-line-tool)
+  - [Sense Keypad](#sense-keypad)
   - [Home Assistant](#home-assistant)
   - [Tested On](#tested-on)
 
@@ -179,7 +180,7 @@ root:
 ```
 
 ### sensors.yaml
-This file will store basic information about each sensor paired to the Wyse Sense Bridge. The entries can be modified to set the class type and sensor name as it will show in Home Assistant. Class types can be automatically filled for `opening`, `motion`, and `moisture`, depending on the type of sensor. Since this file can be automatically generated, Python may automatically quote the MACs or not depending on if they are fully numeric.
+This file will store basic information about each sensor paired to the Wyse Sensor Bridge. The entries can be modified to set the class type and sensor name as it will show in Home Assistant. Class types can be automatically filled for `opening`, `motion`, and `moisture`, depending on the type of sensor. Since this file can be automatically generated, Python may automatically quote the MACs or not depending on if they are fully numeric.
 ```yaml
 'AAAAAAAA':
   class: door
@@ -202,7 +203,6 @@ This file will store basic information about each sensor paired to the Wyse Sens
   name: Basement Moisture
   invert_state: true
 ```
-
 
 ## Usage
 ### Pairing a Sensor
@@ -232,10 +232,29 @@ Once run it will present a menu of its functions:
 * F - Fix invalid sensors (Removes sensors with invalid MACs, common problem with broken sensors or low batteries)
 
 
+### Sense Keypad
+After flashing firmware from the [Sense Hub](https://wyze.com/home-security-system-sensors.html) to the original Sensor Bridge, this project can now support the [Sense Keypad](https://wyze.com/wyze-sense-keypad.html) as well! This entails either [dumping firmware from your own Hub](https://github.com/HclX/WyzeHacks/issues/111#issuecomment-824558304) or using firmware that has already been dumped, and then flashing it. Using the [WyzeSenseUpgrade](https://github.com/AK5nowman/WyzeSense) project is recommended, but is considered "use at your own risk". When a keypad is paired with WyzeSense2MQTT, it will send auto-discovery topics which allow control and statuses from within Home Assistant. The entry in `sensors.yaml` for the keypad looks like the following:
+```yaml
+'FFFFFFFF':
+  class: alarm_control_panel
+  pin: '0000'
+  arm_required: true
+  disarm_required: true
+  invert_state: false
+  name: Front Door Keypad
+```
+
+- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Setting this to `"REMOTE_CODE"` will allow Home Assistant (when configured for discovery) to accept any PIN.
+- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad
+- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad
+- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors
+
+
 ## Home Assistant
-Home Assistant simply needs to be configured with the MQTT broker that the gateway publishes topics to. Once configured, the MQTT integration will automatically add devices for each sensor along with entites for the state, battery_level, and signal_strength. By default these entities will have a device_class of "opening" for contact sensors, "motion" for motion sensors, and "moisture" for leak sensors. They will be named for the sensor type and MAC, e.g. Wyze Sense Contact Sensor AABBCCDD. To adjust the device_class to "door" or "window", and set a custom name, update the sensors.yaml configuration file and replace the defaults, then restart WyzeSense2MQTT. For a comprehensive list of device classes the Home Assistant recognizes, see the [`binary_sensor` documentation](https://www.home-assistant.io/integrations/binary_sensor/).
+Home Assistant simply needs to be configured with the MQTT broker that the gateway publishes topics to. Once configured, the MQTT integration will automatically add devices for each sensor along with entites for the state, battery_level, and signal_strength. By default these entities will have a device_class of "opening" for contact sensors, "motion" for motion sensors, and "moisture" for leak sensors. They will be named for the sensor type and MAC, e.g. Wyze Sense Contact Sensor AABBCCDD. To adjust the device_class to "door" or "window", and set a custom name, update the `sensors.yaml` configuration file and replace the defaults, then restart WyzeSense2MQTT. For a comprehensive list of device classes the Home Assistant recognizes, see the [`binary_sensor` documentation](https://www.home-assistant.io/integrations/binary_sensor/).
 
 
 ## Tested On
+* Ubuntu 20.04 (Docker)
 * Debian Buster (Docker)
 * Raspbian Buster (RPi 4)

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Please submit pull requests against the devel branch.
     - [Removing a Sensor](#removing-a-sensor)
     - [Reload Sensors](#reload-sensors)
     - [Command Line Tool](#command-line-tool)
+  - [Sense Keypad](#sense-keypad)
   - [Home Assistant](#home-assistant)
   - [Compatible Hardware](#compatible-hardware)
 
@@ -244,3 +245,20 @@ Home Assistant simply needs to be configured with the MQTT broker that the gatew
     * Climate Sensor (WSCS1) - Coming Soon Hopefully
     * Keypad (WSKP1) - Coming Soon Hopefully
     * Leak Sensor (WSLS1) - Coming Soon Hopefully
+
+### Sense Keypad
+After flashing firmware from the [Sense Hub](https://wyze.com/home-security-system-sensors.html) to the original Sensor Bridge, this project can now support the [Sense Keypad](https://wyze.com/wyze-sense-keypad.html) as well! This entails either [dumping firmware from your own Hub](https://github.com/HclX/WyzeHacks/issues/111#issuecomment-824558304) or using firmware that has already been dumped, and then flashing it. Using the [WyzeSenseUpgrade](https://github.com/AK5nowman/WyzeSense) project is recommended, but is considered "use at your own risk". When a keypad is paired with WyzeSense2MQTT, it will send auto-discovery topics which allow control and statuses from within Home Assistant. The entry in `sensors.yaml` for the keypad looks like the following:
+```yaml
+'FFFFFFFF':
+  class: alarm_control_panel
+  pin: '0000'
+  arm_required: true
+  disarm_required: true
+  invert_state: false
+  name: Front Door Keypad
+```
+
+- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Setting this to `"REMOTE_CODE"` will allow Home Assistant (when configured for discovery) to accept any PIN.
+- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad
+- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad
+- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors

--- a/readme.md
+++ b/readme.md
@@ -238,16 +238,18 @@ After flashing firmware from the [Sense Hub](https://wyze.com/home-security-syst
 'FFFFFFFF':
   class: alarm_control_panel
   pin: '0000'
+  expose_pin: false
   arm_required: true
   disarm_required: true
   invert_state: false
   name: Front Door Keypad
 ```
 
-- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Setting this to `"REMOTE_CODE"` will allow Home Assistant (when configured for discovery) to accept any PIN.
-- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad
-- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad
-- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors
+- `pin` must be a string (surrounded by single or double quotes) of digits, but can be any length. Can also be a list of PIN strings, which will be validated against.
+- `expose_pin` can be either `true` or `false`. If `true`, a `sensor` entity will be exposed to MQTT discovery which contains the most recent PIN entered. The same PIN will also be saved in the MQTT broker.
+- `arm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to arm the keypad.
+- `disarm_required` can be either `true` or `false`, and determines whether a pin is required to have been entered to disarm the keypad.
+- `invert_state` can be either `true` or `false`, and affects the motion sensor of the keypad, similarly to other supported sensors.
 
 
 ## Home Assistant

--- a/wyzesense2mqtt/wyzesense.py
+++ b/wyzesense2mqtt/wyzesense.py
@@ -1,12 +1,14 @@
+import binascii
+
 from builtins import bytes
 from builtins import str
 
+import datetime
+import logging
 import os
-import time
 import struct
 import threading
-import datetime
-import binascii
+import time
 
 import logging
 
@@ -80,7 +82,10 @@ class Packet(object):
         if self._cmd == self.ASYNC_ACK:
             return "Packet: Cmd=%04X, Payload=ACK(%04X)" % (self._cmd, self._payload)
         else:
-            return "Packet: Cmd=%04X, Payload=%s" % (self._cmd, bytes_to_hex(self._payload))
+            return "Packet: Cmd=%04X, Payload=%s" % (
+                self._cmd,
+                bytes_to_hex(self._payload),
+            )
 
     @property
     def Length(self):
@@ -433,7 +438,7 @@ class Dongle(object):
 
         # LOGGER.debug("Raw HID packet: %s", bytes_to_hex(s))
         assert len(s) >= length + 1
-        return s[1: 1 + length]
+        return s[1 : 1 + length]
 
     def _SetHandler(self, cmd, handler):
         with self.__lock:
@@ -652,7 +657,11 @@ class Dongle(object):
 
         def scan_handler(pkt):
             assert len(pkt.Payload) == 11
-            ctx.result = (pkt.Payload[1:9].decode('ascii'), pkt.Payload[9], pkt.Payload[10])
+            ctx.result = (
+                pkt.Payload[1:9].decode('ascii'),
+                pkt.Payload[9],
+                pkt.Payload[10],
+            )
             ctx.evt.set()
 
         old_handler = self._SetHandler(Packet.NOTIFY_SENSOR_SCAN, scan_handler)

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -5,6 +5,7 @@ import json
 import logging
 import logging.config
 import logging.handlers
+import paho.mqtt.subscribe as subscribe
 import os
 import shutil
 import subprocess
@@ -31,7 +32,8 @@ SENSORS_CONFIG_FILE = "sensors.yaml"
 DEVICE_CLASSES = {
     **dict.fromkeys([0x01, 0x0E, 'switch', 'switchv2'], 'opening'),
     **dict.fromkeys([0x02, 0x0F, 'motion', 'motionv2'], 'motion'),
-    **dict.fromkeys([0x03, 'leak'], 'moisture')
+    **dict.fromkeys([0x03, 'leak'], 'moisture'),
+    **dict.fromkeys([0x05, 'keypad'], 'alarm_control_panel'),
 }
 
 # Read data from YAML file
@@ -235,9 +237,15 @@ def add_sensor_to_config(sensor_mac, sensor_type, sensor_version):
     SENSORS[sensor_mac] = {
         'name': f"Wyze Sense {sensor_mac}",
         'class': DEVICE_CLASSES.get(sensor_type),
-        'invert_state': False
+        'invert_state': False,
     }
-    if (sensor_version is not None):
+
+    if DEVICE_CLASSES.get(sensor_type) == "alarm_control_panel":
+        SENSORS[sensor_mac].update(
+            {'pin': '0000', 'arm_required': True, 'disarm_required': True}
+        )
+
+    if sensor_version is not None:
         SENSORS[sensor_mac]['sw_version'] = sensor_version
 
     write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE), SENSORS)
@@ -267,6 +275,24 @@ def mqtt_publish(mqtt_topic, mqtt_payload):
         LOGGER.warning(f"MQTT publish error: {mqtt.error_string(mqtt_message_info.rc)}")
 
 
+def mqtt_simple_subscribe(mqtt_topic):
+    global MQTT_CLIENT, CONFIG
+    msg = subscribe.simple(
+        mqtt_topic,
+        qos=CONFIG['mqtt_qos'],
+        retained=True,
+        hostname=CONFIG['mqtt_host'],
+        port=CONFIG['mqtt_port'],
+        client_id=CONFIG['mqtt_client_id'],
+        auth={'username': CONFIG['mqtt_username'], 'password': CONFIG['mqtt_password']}
+        if CONFIG['mqtt_username']
+        else None,
+        keepalive=CONFIG['mqtt_keepalive'],
+    )
+
+    return json.loads(msg.payload)
+
+
 # Send discovery topics
 def send_discovery_topics(sensor_mac):
     global SENSORS, CONFIG
@@ -280,43 +306,97 @@ def send_discovery_topics(sensor_mac):
     else:
         sensor_version = ""
 
+    model = "Sense {}"
+    if sensor_class == "motion":
+        model = model.format("Motion Sensor")
+    elif sensor_class == "opening":
+        model = model.format("Contact Sensor")
+    elif sensor_class == "keypad":
+        model = model.format("Keypad")
+    else:
+        model = model.format("Device")
+
     device_payload = {
         'identifiers': [f"wyzesense_{sensor_mac}", sensor_mac],
         'manufacturer': "Wyze",
-        'model': (
-            "Sense Motion Sensor" if (sensor_class == "motion")
-            else "Sense Contact Sensor"
-        ),
+        'model': model,
         'name': sensor_name,
-        'sw_version': sensor_version
+        'sw_version': sensor_version,
     }
 
     entity_payloads = {
-        'state': {
-            'name': sensor_name,
-            'dev_cla': sensor_class,
-            'pl_on': "1",
-            'pl_off': "0",
-            'json_attr_t': f"{CONFIG['self_topic_root']}/{sensor_mac}"
-        },
         'signal_strength': {
             'name': f"{sensor_name} Signal Strength",
             'dev_cla': "signal_strength",
-            'unit_of_meas': "dBm"
+            'unit_of_meas': "dBm",
         },
         'battery': {
             'name': f"{sensor_name} Battery",
             'dev_cla': "battery",
-            'unit_of_meas': "%"
-        }
+            'unit_of_meas': "%",
+        },
     }
 
+    if sensor_class != "alarm_control_panel":
+        entity_payloads.update(
+            {
+                'state': {
+                    'name': sensor_name,
+                    'dev_cla': sensor_class,
+                    'pl_on': "1",
+                    'pl_off': "0",
+                    'json_attr_t': f"{CONFIG['self_topic_root']}/{sensor_mac}",
+                },
+            }
+        )
+    else:
+        entity_payloads.update(
+            {
+                'mode': {
+                    'name': sensor_name,
+                    'pl_arm_away': "armed_away",
+                    'pl_arm_home': "armed_home",
+                    'pl_disarm': "disarmed",
+                    'code': SENSORS[sensor_mac]['pin'],
+                    'code_arm_required': SENSORS[sensor_mac]['arm_required'],
+                    'code_disarm_required': SENSORS[sensor_mac]['disarm_required'],
+                    'stat_t': f"{CONFIG['self_topic_root']}/{sensor_mac}/mode",
+                    'val_tpl': f"{{{{ value_json.state }}}}",
+                    'cmd_t': f"{CONFIG['self_topic_root']}/{sensor_mac}/set",
+                    'cmd_tpl': '{ "mode": "{{ action }}", "pin": "{{ code }}" }',
+                },
+                'motion': {
+                    'name': f"{sensor_name} Motion",
+                    'dev_cla': 'motion',
+                    'pl_on': "1",
+                    'pl_off': "0",
+                    'val_tpl': f"{{{{ value_json.state }}}}",
+                    'stat_t': f"{CONFIG['self_topic_root']}/{sensor_mac}/motion",
+                },
+            }
+        )
+
     for entity, entity_payload in entity_payloads.items():
-        entity_payload['val_tpl'] = f"{{{{ value_json.{entity} }}}}"
+        entity_payload['val_tpl'] = entity_payload.get(
+            'val_tpl', f"{{{{ value_json.{entity} }}}}"
+        )
         entity_payload['uniq_id'] = f"wyzesense_{sensor_mac}_{entity}"
-        entity_payload['stat_t'] = f"{CONFIG['self_topic_root']}/{sensor_mac}"
+        entity_payload['stat_t'] = entity_payload.get(
+            'stat_t', f"{CONFIG['self_topic_root']}/{sensor_mac}"
+        )
         entity_payload['dev'] = device_payload
-        sensor_type = ("binary_sensor" if (entity == "state") else "sensor")
+        sensor_type = ""
+        if sensor_class != "alarm_control_panel":
+            sensor_type = "binary_sensor" if (entity == "state") else "sensor"
+        else:
+            if entity == "mode":
+                sensor_type = "alarm_control_panel"
+                entity = "state"
+            elif entity == "motion":
+                sensor_type = "binary_sensor"
+                entity = "state"
+            else:
+                sensor_type = "sensor"
 
         entity_topic = f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity}/config"
         mqtt_publish(entity_topic, entity_payload)
@@ -326,34 +406,43 @@ def send_discovery_topics(sensor_mac):
 
 # Clear any retained topics in MQTT
 def clear_topics(sensor_mac):
-    global CONFIG
+    global CONFIG, SENSORS
     LOGGER.info("Clearing sensor topics")
     state_topic = f"{CONFIG['self_topic_root']}/{sensor_mac}"
     mqtt_publish(state_topic, None)
+    if SENSORS[sensor_mac]['class'] == 'alarm_control_panel':
+        for i in ['/mode', '/motion', '/pin', '/set']:
+            mqtt_publish(state_topic + i, None)
 
     # clear discovery topics if configured
-    if(CONFIG['hass_discovery']):
-        entity_types = ['state', 'signal_strength', 'battery']
+    if CONFIG['hass_discovery']:
+        entity_types = {
+            'sensor': ['battery', 'signal_strength'],
+            'binary_sensor': ['state'],
+            'alarm_control_panel': ['state'],
+        }
+
         for entity_type in entity_types:
-            sensor_type = (
-                "binary_sensor" if (entity_type == "state")
-                else "sensor"
-            )
-            entity_topic = f"{CONFIG['hass_topic_root']}/{sensor_type}/wyzesense_{sensor_mac}/{entity_type}/config"
-            mqtt_publish(entity_topic, None)
+            for entity in entity_types[entity_type]:
+                entity_topic = f"{CONFIG['hass_topic_root']}/{entity_type}/wyzesense_{sensor_mac}/{entity}/config"
+                mqtt_publish(entity_topic, None)
 
 
 def on_connect(MQTT_CLIENT, userdata, flags, rc):
     global CONFIG
     if rc == mqtt.MQTT_ERR_SUCCESS:
         MQTT_CLIENT.subscribe(
-            [(SCAN_TOPIC, CONFIG['mqtt_qos']),
-             (REMOVE_TOPIC, CONFIG['mqtt_qos']),
-             (RELOAD_TOPIC, CONFIG['mqtt_qos'])]
+            [
+                (SCAN_TOPIC, CONFIG['mqtt_qos']),
+                (REMOVE_TOPIC, CONFIG['mqtt_qos']),
+                (RELOAD_TOPIC, CONFIG['mqtt_qos']),
+                (SET_TOPIC, CONFIG['mqtt_qos']),
+            ]
         )
         MQTT_CLIENT.message_callback_add(SCAN_TOPIC, on_message_scan)
         MQTT_CLIENT.message_callback_add(REMOVE_TOPIC, on_message_remove)
         MQTT_CLIENT.message_callback_add(RELOAD_TOPIC, on_message_reload)
+        MQTT_CLIENT.message_callback_add(SET_TOPIC, on_message_set)
         # Used for alternate MQTT connection method
         # MQTT_CLIENT.connected_flag = True
         LOGGER.info(f"Connected to MQTT: {mqtt.error_string(rc)}")
@@ -365,6 +454,7 @@ def on_disconnect(MQTT_CLIENT, userdata, rc):
     MQTT_CLIENT.message_callback_remove(SCAN_TOPIC)
     MQTT_CLIENT.message_callback_remove(REMOVE_TOPIC)
     MQTT_CLIENT.message_callback_remove(RELOAD_TOPIC)
+    MQTT_CLIENT.message_callback_remove(SET_TOPIC)
     # Used for alternate MQTT connection method
     # MQTT_CLIENT.connected_flag = False
     LOGGER.info(f"Disconnected from MQTT: {mqtt.error_string(rc)}")
@@ -424,6 +514,47 @@ def on_message_reload(MQTT_CLIENT, userdata, msg):
     init_sensors()
 
 
+# Process message to set keypad state
+def on_message_set(MQTT_CLIENT, userdata, msg):
+    LOGGER.info(f"In on_message_set: {msg.payload.decode()}")
+    parts = msg.topic.split('/')
+    payload = json.loads(msg.payload)
+    if payload and payload['mode'] is not None:
+        set_keypad_mode(parts[1], payload)
+
+
+def set_keypad_mode(keypad_mac, payload):
+    mode = payload['mode']
+    pin = payload['pin']
+
+    if not validate_pin_entry(keypad_mac, mode, pin):
+        return
+
+    mode_payload = {'state': mode}
+
+    mode_topic = f"{CONFIG['self_topic_root']}/{keypad_mac}/mode"
+    set_topic = f"{CONFIG['self_topic_root']}/{keypad_mac}/set"
+
+    mqtt_publish(mode_topic, mode_payload)
+    mqtt_publish(set_topic, {'mode': None, 'pin': False})
+
+
+def validate_pin_entry(mac, mode, pin=None):
+    pin_topic = f"{CONFIG['self_topic_root']}/{mac}/pin"
+    config = SENSORS[mac]
+
+    if pin is None:
+        pin = mqtt_simple_subscribe(pin_topic)['state']
+
+    if pin != config['pin']:
+        if (mode in ["armed_away", "armed_home"] and config['arm_required']) or (
+            mode == "disarmed" and config['disarm_required']
+        ):
+            return False
+
+    return True
+
+
 # Process event
 def on_event(WYZESENSE_DONGLE, event):
     global SENSORS
@@ -431,30 +562,34 @@ def on_event(WYZESENSE_DONGLE, event):
     # List of states that correlate to ON.
     STATES_ON = ['active', 'open', 'wet']
 
-    if (valid_sensor_mac(event.MAC)):
-        if (event.Type == "alarm") or (event.Type == "status"):
+    if valid_sensor_mac(event.MAC):
+        # Build event payload
+        event_payload = {
+            'event': event.Type,
+            'available': True,
+            'mac': event.MAC,
+            'last_seen': event.Timestamp.timestamp(),
+            'last_seen_iso': event.Timestamp.isoformat(),
+        }
+
+        if event.Type in ["alarm", "status", "keypad"]:
             LOGGER.info(f"State event data: {event}")
-            (sensor_type, sensor_state, sensor_battery, sensor_signal) = event.Data
+            (event_type, sensor_state, sensor_battery, sensor_signal) = event.Data
+            event_payload.update(
+                {'signal_strength': sensor_signal * -1, 'battery': sensor_battery}
+            )
 
             # Add sensor if it doesn't already exist
-            if (event.MAC not in SENSORS):
-                add_sensor_to_config(event.MAC, sensor_type, None)
-                if(CONFIG['hass_discovery']):
+            if event.MAC not in SENSORS:
+                add_sensor_to_config(event.MAC, event_type, None)
+                if CONFIG['hass_discovery']:
                     send_discovery_topics(event.MAC)
 
-            # Build event payload
-            event_payload = {
-                'event': event.Type,
-                'available': True,
-                'mac': event.MAC,
-                'device_class': DEVICE_CLASSES.get(sensor_type),
-                'last_seen': event.Timestamp.timestamp(),
-                'last_seen_iso': event.Timestamp.isoformat(),
-                'signal_strength': sensor_signal * -1,
-                'battery': sensor_battery
-            }
+        if event.Type in ["alarm", "status"]:
+            event_payload['device_class'] = DEVICE_CLASSES.get(event_type)
+            state_topic = f"{CONFIG['self_topic_root']}/{event.MAC}"
 
-            if (CONFIG['publish_sensor_name']):
+            if CONFIG['publish_sensor_name']:
                 event_payload['name'] = SENSORS[event.MAC]['name']
 
             # Set state depending on state string and `invert_state` setting.
@@ -462,14 +597,35 @@ def on_event(WYZESENSE_DONGLE, event):
             #     State OFF ^ NOT Inverted = False
             #     State ON ^ Inverted = False
             #     State OFF ^ Inverted = True
-            event_payload['state'] = int((sensor_state in STATES_ON) ^ (SENSORS[event.MAC].get('invert_state')))
+            event_payload['state'] = int(
+                (sensor_state in STATES_ON) ^ (SENSORS[event.MAC].get('invert_state'))
+            )
 
+            mqtt_publish(state_topic, event_payload)
             LOGGER.debug(event_payload)
+        elif event.Type == "keypad":
+            state_payload = {"state": sensor_state}
 
             state_topic = f"{CONFIG['self_topic_root']}/{event.MAC}"
+            event_topic = f"{CONFIG['self_topic_root']}/{event.MAC}/{event_type}"
+            pin_topic = f"{CONFIG['self_topic_root']}/{event.MAC}/pin"
+            set_topic = f"{CONFIG['self_topic_root']}/{event.MAC}/set"
+
             mqtt_publish(state_topic, event_payload)
-        else:
-            LOGGER.debug(f"Non-state event data: {event}")
+
+            if event_type == "mode" and not validate_pin_entry(event.MAC, sensor_state):
+                return
+
+            if event_type in ["mode", "motion"]:
+                mqtt_publish(event_topic, state_payload)
+                mqtt_publish(pin_topic, {'state': False})
+                if event_type == "mode" or sensor_state == "inactive":
+                    mqtt_publish(set_topic, {'mode': None, 'pin': False})
+            elif event_type in ['pinStart', 'pinConfirm']:
+                mqtt_publish(pin_topic, state_payload)
+
+            event_payload.update(state_payload)
+            LOGGER.debug(event_payload)
 
     else:
         LOGGER.warning("!Invalid MAC detected!")
@@ -487,6 +643,7 @@ if __name__ == "__main__":
     SCAN_TOPIC = f"{CONFIG['self_topic_root']}/scan"
     REMOVE_TOPIC = f"{CONFIG['self_topic_root']}/remove"
     RELOAD_TOPIC = f"{CONFIG['self_topic_root']}/reload"
+    SET_TOPIC = f"{CONFIG['self_topic_root']}/+/set"
 
     # Initialize MQTT client connection
     init_mqtt_client()

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -5,16 +5,19 @@ import json
 import logging
 import logging.config
 import logging.handlers
+
+import paho.mqtt.client as mqtt
 import paho.mqtt.subscribe as subscribe
+
 import os
+
+from retrying import retry
+
 import shutil
 import subprocess
 import yaml
 
-
-import paho.mqtt.client as mqtt
 import wyzesense
-from retrying import retry
 
 
 # Configuration File Locations
@@ -40,7 +43,7 @@ def read_yaml_file(filename):
             data = yaml.safe_load(yaml_file)
             return data
     except IOError as error:
-        if (LOGGER is None):
+        if LOGGER is None:
             print(f"File error: {str(error)}")
         else:
             LOGGER.error(f"File error: {str(error)}")
@@ -52,7 +55,7 @@ def write_yaml_file(filename, data):
         with open(filename, 'w') as yaml_file:
             yaml_file.write(yaml.safe_dump(data))
     except IOError as error:
-        if (LOGGER is None):
+        if LOGGER is None:
             print(f"File error: {str(error)}")
         else:
             LOGGER.error(f"File error: {str(error)}")
@@ -61,7 +64,7 @@ def write_yaml_file(filename, data):
 # Initialize logging
 def init_logging():
     global LOGGER
-    if (not os.path.isfile(os.path.join(CONFIG_PATH, LOGGING_CONFIG_FILE))):
+    if not os.path.isfile(os.path.join(CONFIG_PATH, LOGGING_CONFIG_FILE)):
         print("Copying default logging config file...")
         try:
             shutil.copy2(os.path.join(SAMPLES_PATH, LOGGING_CONFIG_FILE), CONFIG_PATH)
@@ -71,7 +74,7 @@ def init_logging():
 
     log_path = os.path.dirname(logging_config['handlers']['file']['filename'])
     try:
-        if (not os.path.exists(log_path)):
+        if not os.path.exists(log_path):
             os.makedirs(log_path)
     except IOError:
         print("Unable to create log folder")
@@ -86,21 +89,21 @@ def init_config():
     LOGGER.debug("Initializing configuration...")
 
     # load base config - allows for auto addition of new settings
-    if (os.path.isfile(os.path.join(SAMPLES_PATH, MAIN_CONFIG_FILE))):
+    if os.path.isfile(os.path.join(SAMPLES_PATH, MAIN_CONFIG_FILE)):
         CONFIG = read_yaml_file(os.path.join(SAMPLES_PATH, MAIN_CONFIG_FILE))
 
     # load user config over base
-    if (os.path.isfile(os.path.join(CONFIG_PATH, MAIN_CONFIG_FILE))):
+    if os.path.isfile(os.path.join(CONFIG_PATH, MAIN_CONFIG_FILE)):
         user_config = read_yaml_file(os.path.join(CONFIG_PATH, MAIN_CONFIG_FILE))
         CONFIG.update(user_config)
 
     # fail on no config
-    if (CONFIG is None):
+    if CONFIG is None:
         LOGGER.error(f"Failed to load configuration, please configure.")
         exit(1)
 
     # write updated config file if needed
-    if (CONFIG != user_config):
+    if CONFIG != user_config:
         LOGGER.info("Writing updated config file")
         write_yaml_file(os.path.join(CONFIG_PATH, MAIN_CONFIG_FILE), CONFIG)
 
@@ -110,8 +113,12 @@ def init_mqtt_client():
     global MQTT_CLIENT, CONFIG, LOGGER
 
     # Configure MQTT Client
-    MQTT_CLIENT = mqtt.Client(client_id=CONFIG['mqtt_client_id'], clean_session=CONFIG['mqtt_clean_session'])
-    MQTT_CLIENT.username_pw_set(username=CONFIG['mqtt_username'], password=CONFIG['mqtt_password'])
+    MQTT_CLIENT = mqtt.Client(
+        client_id=CONFIG['mqtt_client_id'], clean_session=CONFIG['mqtt_clean_session']
+    )
+    MQTT_CLIENT.username_pw_set(
+        username=CONFIG['mqtt_username'], password=CONFIG['mqtt_password']
+    )
     MQTT_CLIENT.reconnect_delay_set(min_delay=1, max_delay=120)
     MQTT_CLIENT.on_connect = on_connect
     MQTT_CLIENT.on_disconnect = on_disconnect
@@ -133,27 +140,35 @@ def retry_if_io_error(exception):
 
 
 # Initialize USB dongle
-@retry(wait_exponential_multiplier=1000, wait_exponential_max=30000, retry_on_exception=retry_if_io_error)
+@retry(
+    wait_exponential_multiplier=1000,
+    wait_exponential_max=30000,
+    retry_on_exception=retry_if_io_error,
+)
 def init_wyzesense_dongle():
     global WYZESENSE_DONGLE, CONFIG
-    if (CONFIG['usb_dongle'].lower() == "auto"):
-        device_list = subprocess.check_output(
-            ["ls", "-la", "/sys/class/hidraw"]
-        ).decode("utf-8").lower()
+    if CONFIG['usb_dongle'].lower() == "auto":
+        device_list = (
+            subprocess.check_output(["ls", "-la", "/sys/class/hidraw"])
+            .decode("utf-8")
+            .lower()
+        )
         for line in device_list.split("\n"):
-            if (("e024" in line) and ("1a86" in line)):
+            if ("e024" in line) and ("1a86" in line):
                 for device_name in line.split(" "):
-                    if ("hidraw" in device_name):
+                    if "hidraw" in device_name:
                         CONFIG['usb_dongle'] = f"/dev/{device_name}"
                         break
 
     LOGGER.info(f"Connecting to dongle {CONFIG['usb_dongle']}")
     try:
         WYZESENSE_DONGLE = wyzesense.Open(CONFIG['usb_dongle'], on_event)
-        LOGGER.debug(f"Dongle {CONFIG['usb_dongle']}: ["
-                     f" MAC: {WYZESENSE_DONGLE.MAC},"
-                     f" VER: {WYZESENSE_DONGLE.Version},"
-                     f" ENR: {WYZESENSE_DONGLE.ENR}]")
+        LOGGER.debug(
+            f"Dongle {CONFIG['usb_dongle']}: ["
+            f" MAC: {WYZESENSE_DONGLE.MAC},"
+            f" VER: {WYZESENSE_DONGLE.Version},"
+            f" ENR: {WYZESENSE_DONGLE.ENR}]"
+        )
     except IOError as error:
         LOGGER.warning(f"No device found on path {CONFIG['usb_dongle']}: {str(error)}")
 
@@ -166,7 +181,7 @@ def init_sensors():
 
     # Load config file
     LOGGER.debug("Reading sensors configuration...")
-    if (os.path.isfile(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE))):
+    if os.path.isfile(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE)):
         SENSORS = read_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE))
         sensors_config_file_found = True
     else:
@@ -183,10 +198,10 @@ def init_sensors():
     try:
         result = WYZESENSE_DONGLE.List()
         LOGGER.debug(f"Linked sensors: {result}")
-        if (result):
+        if result:
             for sensor_mac in result:
-                if (valid_sensor_mac(sensor_mac)):
-                    if (SENSORS.get(sensor_mac) is None):
+                if valid_sensor_mac(sensor_mac):
+                    if SENSORS.get(sensor_mac) is None:
                         add_sensor_to_config(sensor_mac, None, None)
         else:
             LOGGER.warning(f"Sensor list failed with result: {result}")
@@ -194,7 +209,7 @@ def init_sensors():
         pass
 
     # Save sensors file if didn't exist
-    if (not sensors_config_file_found):
+    if not sensors_config_file_found:
         LOGGER.info("Writing Sensors Config File")
         write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE), SENSORS)
 
@@ -208,13 +223,13 @@ def init_sensors():
 
 # Validate sensor MAC
 def valid_sensor_mac(sensor_mac):
-    #LOGGER.debug(f"Validating MAC: {sensor_mac}")
+    # LOGGER.debug(f"Validating MAC: {sensor_mac}")
     invalid_mac_list = [
         "00000000",
         "\0\0\0\0\0\0\0\0",
-        "\x00\x00\x00\x00\x00\x00\x00\x00"
+        "\x00\x00\x00\x00\x00\x00\x00\x00",
     ]
-    if ((len(str(sensor_mac)) == 8) and (sensor_mac not in invalid_mac_list)):
+    if (len(str(sensor_mac)) == 8) and (sensor_mac not in invalid_mac_list):
         return True
     else:
         LOGGER.warning(f"Unpairing bad MAC: {sensor_mac}")
@@ -265,9 +280,9 @@ def mqtt_publish(mqtt_topic, mqtt_payload):
         mqtt_topic,
         payload=json.dumps(mqtt_payload),
         qos=CONFIG['mqtt_qos'],
-        retain=CONFIG['mqtt_retain']
+        retain=CONFIG['mqtt_retain'],
     )
-    if (mqtt_message_info.rc != mqtt.MQTT_ERR_SUCCESS):
+    if mqtt_message_info.rc != mqtt.MQTT_ERR_SUCCESS:
         LOGGER.warning(f"MQTT publish error: {mqtt.error_string(mqtt_message_info.rc)}")
 
 
@@ -297,7 +312,7 @@ def send_discovery_topics(sensor_mac):
 
     sensor_name = SENSORS[sensor_mac]['name']
     sensor_class = SENSORS[sensor_mac]['class']
-    if (SENSORS[sensor_mac].get('sw_version') is not None):
+    if SENSORS[sensor_mac].get('sw_version') is not None:
         sensor_version = SENSORS[sensor_mac]['sw_version']
     else:
         sensor_version = ""
@@ -467,16 +482,12 @@ def on_message_scan(MQTT_CLIENT, userdata, msg):
     try:
         result = WYZESENSE_DONGLE.Scan()
         LOGGER.debug(f"Scan result: {result}")
-        if (result):
+        if result:
             sensor_mac, sensor_type, sensor_version = result
-            if (valid_sensor_mac(sensor_mac)):
+            if valid_sensor_mac(sensor_mac):
                 if (SENSORS.get(sensor_mac)) is None:
-                    add_sensor_to_config(
-                        sensor_mac,
-                        sensor_type,
-                        sensor_version
-                    )
-                    if(CONFIG['hass_discovery']):
+                    add_sensor_to_config(sensor_mac, sensor_type, sensor_version)
+                    if CONFIG['hass_discovery']:
                         send_discovery_topics(sensor_mac)
             else:
                 LOGGER.debug(f"Invalid sensor found: {sensor_mac}")
@@ -491,7 +502,7 @@ def on_message_remove(MQTT_CLIENT, userdata, msg):
     LOGGER.info(f"In on_message_remove: {msg.payload.decode()}")
     sensor_mac = msg.payload.decode()
 
-    if (valid_sensor_mac(sensor_mac)):
+    if valid_sensor_mac(sensor_mac):
         try:
             WYZESENSE_DONGLE.Delete(sensor_mac)
             clear_topics(sensor_mac)

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -540,6 +540,7 @@ def send_discovery_topics(sensor_mac, wait=True):
                     'pl_arm_away': "armed_away",
                     'pl_arm_home': "armed_home",
                     'pl_disarm': "disarmed",
+                    'payload_trigger': "triggered",
                     'code': "REMOTE_CODE"
                     if type(SENSORS[sensor_mac]['pin']) == list
                     else SENSORS[sensor_mac]['pin'],

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -174,9 +174,10 @@ def init_sensors():
         sensors_config_file_found = False
 
     # Add invert_state value if missing
-    for sensor_mac in SENSORS:
-        if (SENSORS[sensor_mac].get('invert_state') is None):
-            SENSORS[sensor_mac]['invert_state'] = False
+    if SENSORS:
+        for sensor_mac in SENSORS:
+            if SENSORS[sensor_mac].get('invert_state') is None:
+                SENSORS[sensor_mac]['invert_state'] = False
 
     # Check config against linked sensors
     try:
@@ -198,10 +199,11 @@ def init_sensors():
         write_yaml_file(os.path.join(CONFIG_PATH, SENSORS_CONFIG_FILE), SENSORS)
 
     # Send discovery topics
-    if(CONFIG['hass_discovery']):
-        for sensor_mac in SENSORS:
-            if (valid_sensor_mac(sensor_mac)):
-                send_discovery_topics(sensor_mac)
+    if CONFIG['hass_discovery']:
+        if SENSORS:
+            for sensor_mac in SENSORS:
+                if valid_sensor_mac(sensor_mac):
+                    send_discovery_topics(sensor_mac)
 
 
 # Validate sensor MAC

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -11,9 +11,6 @@ import shutil
 import subprocess
 import yaml
 
-# Used for alternate MQTT connection method
-# import signal
-# import time
 
 import paho.mqtt.client as mqtt
 import wyzesense
@@ -111,8 +108,6 @@ def init_config():
 # Initialize MQTT client connection
 def init_mqtt_client():
     global MQTT_CLIENT, CONFIG, LOGGER
-    # Used for alternate MQTT connection method
-    # mqtt.Client.connected_flag = False
 
     # Configure MQTT Client
     MQTT_CLIENT = mqtt.Client(client_id=CONFIG['mqtt_client_id'], clean_session=CONFIG['mqtt_clean_session'])
@@ -125,12 +120,11 @@ def init_mqtt_client():
 
     # Connect to MQTT
     LOGGER.info(f"Connecting to MQTT host {CONFIG['mqtt_host']}")
-    MQTT_CLIENT.connect_async(CONFIG['mqtt_host'], port=CONFIG['mqtt_port'], keepalive=CONFIG['mqtt_keepalive'])
-
-    # Used for alternate MQTT connection method
-    # MQTT_CLIENT.loop_start()
-    # while (not MQTT_CLIENT.connected_flag):
-    #     time.sleep(1)
+    MQTT_CLIENT.connect_async(
+        CONFIG['mqtt_host'],
+        port=CONFIG['mqtt_port'],
+        keepalive=CONFIG['mqtt_keepalive'],
+    )
 
 
 # Retry forever on IO Error
@@ -443,8 +437,7 @@ def on_connect(MQTT_CLIENT, userdata, flags, rc):
         MQTT_CLIENT.message_callback_add(REMOVE_TOPIC, on_message_remove)
         MQTT_CLIENT.message_callback_add(RELOAD_TOPIC, on_message_reload)
         MQTT_CLIENT.message_callback_add(SET_TOPIC, on_message_set)
-        # Used for alternate MQTT connection method
-        # MQTT_CLIENT.connected_flag = True
+
         LOGGER.info(f"Connected to MQTT: {mqtt.error_string(rc)}")
     else:
         LOGGER.warning(f"Connection to MQTT failed: {mqtt.error_string(rc)}")
@@ -455,8 +448,7 @@ def on_disconnect(MQTT_CLIENT, userdata, rc):
     MQTT_CLIENT.message_callback_remove(REMOVE_TOPIC)
     MQTT_CLIENT.message_callback_remove(RELOAD_TOPIC)
     MQTT_CLIENT.message_callback_remove(SET_TOPIC)
-    # Used for alternate MQTT connection method
-    # MQTT_CLIENT.connected_flag = False
+
     LOGGER.info(f"Disconnected from MQTT: {mqtt.error_string(rc)}")
 
 

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -511,7 +511,9 @@ def send_discovery_topics(sensor_mac, wait=True):
                     'pl_arm_away': "armed_away",
                     'pl_arm_home': "armed_home",
                     'pl_disarm': "disarmed",
-                    'code': SENSORS[sensor_mac]['pin'],
+                    'code': "REMOTE_CODE"
+                    if type(SENSORS[sensor_mac]['pin']) == list
+                    else SENSORS[sensor_mac]['pin'],
                     'code_arm_required': SENSORS[sensor_mac]['arm_required'],
                     'code_disarm_required': SENSORS[sensor_mac]['disarm_required'],
                     'stat_t': f"{CONFIG['self_topic_root']}/{sensor_mac}/mode",
@@ -724,17 +726,23 @@ def set_keypad_mode(keypad_mac, payload):
 def validate_pin_entry(mac, mode, pin=None):
     pin_topic = f"{CONFIG['self_topic_root']}/{mac}/pin"
     config = SENSORS[mac]
+    accepted_pins = config['pin'] if type(config['pin']) == list else [config['pin']]
 
     if pin is None:
         pin = mqtt_simple_subscribe(pin_topic)['state']
 
-    if pin != config['pin']:
+    if pin not in accepted_pins:
         if (mode in ["armed_away", "armed_home"] and config['arm_required']) or (
             mode == "disarmed" and config['disarm_required']
         ):
+            LOGGER.debug("PIN rejected, aborting.")
             return False
-
-    return True
+        else:
+            LOGGER.debug(f"PIN not required for {mode}, continuing...")
+            return True
+    else:
+        LOGGER.debug("PIN accepted, continuing...")
+        return True
 
 
 # Process event

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -241,9 +241,10 @@ def init_sensors(wait=True):
         sensors_config_file_found = False
 
     # Add invert_state value if missing
-    for sensor_mac in SENSORS:
-        if (SENSORS[sensor_mac].get('invert_state') is None):
-            SENSORS[sensor_mac]['invert_state'] = False
+    if SENSORS:
+        for sensor_mac in SENSORS:
+            if SENSORS[sensor_mac].get('invert_state') is None:
+                SENSORS[sensor_mac]['invert_state'] = False
 
     # Load previous known states
     if (os.path.isfile(os.path.join(CONFIG_PATH, SENSORS_STATE_FILE))):

--- a/wyzesense2mqtt/wyzesense2mqtt.py
+++ b/wyzesense2mqtt/wyzesense2mqtt.py
@@ -397,6 +397,7 @@ def send_discovery_topics(sensor_mac):
                     'pl_arm_away': "armed_away",
                     'pl_arm_home': "armed_home",
                     'pl_disarm': "disarmed",
+                    'payload_trigger': "triggered",
                     'code': "REMOTE_CODE"
                     if type(SENSORS[sensor_mac]['pin']) == list
                     else SENSORS[sensor_mac]['pin'],


### PR DESCRIPTION
This PR adds support for *only* the Sense Keypad, when using [this firmware](https://github.com/AK5nowman/WyzeSense/blob/master/WyzeSenseUpgrade/firmware/hms_cc1310.bin), flashed to a Sense V1 bridge dongle, via the [WyzeSenseUpgrade](https://github.com/AK5nowman/WyzeSense) project. It is ([or was?](https://github.com/raetha/wyzesense2mqtt/issues/52#issuecomment-952298073)) also possible to dump this firmware for yourself by following [these steps](https://github.com/HclX/WyzeHacks/issues/111#issuecomment-824558304) by @HclX.

I would like to also support the V2 [leak](https://wyze.com/wyze-leak-sensor.html) and [climate](https://wyze.com/wyze-climate-sensor.html) sensors (like #61 attempted to do), but I don't have them available to test with, so I've excluded them from this PR in particular. I have done considerable refactoring in an effort to make them trivial to add support for, if that opportunity ever comes, but have stashed their code away for now.

In addition to simply supporting them, this adds full support for MQTT auto-discovery by Home Assistant:
- Exposes an `alarm_control_panel` entity for the panel itself
- Two-way control from keypad <-> Home Assistant for all states (except `triggered`, which can only be controlled from the physical keypad. It is detected properly inside of Home Assistant when activated on the keypad.)
- Does not hold PIN entries in MQTT broker longer than necessary, unless desired
- Supports "local" and "remote" validation as described in the [MQTT Alarm Control Panel docs](https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#code); more on that later.
- Exposes a `binary_sensor` for motion detection
- Exposes `sensor` entities for battery level and signal strength

Keypad devices can be configured in `sensors.yaml` (and are added automatically when paired, defaults shown below):
```yaml
'ABCDEFGH':
  class: alarm_control_panel
  pin: '0000'
  expose_pin: false
  arm_required: true
  disarm_required: true
  invert_state: false
  name: Wyze Sense ABCDEFGH
  sw_version: 48
```

- `class` must be `alarm_control_panel`
- `arm_required` works as described [here](https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#code_arm_required)
- `disarm_required` works as described [here](https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/#code_disarm_required)
- `invert_state` acts on the motion detection, similarly to the current behavior of regular sensors
- `pin` must be a string of digits, but can be any length. Setting this to `'REMOTE_CODE'` will allow Home Assistant to send any PIN to `wyzesense2mqtt` for validation.
- `expose_pin` determines whether or not to expose the last PIN as an entity and in the MQTT broker

This PR, though containing significant refactoring, should not affect the behavior of other sensors (either already paired ones, or ones added in the future).