### PR TITLE
Fix autodiscovery for chime 'play sound' button

### DIFF
--- a/hub/mqtt.py
+++ b/hub/mqtt.py
@@ -311,10 +311,9 @@ def _build_chime_components(sensor_mac: str, sensor: dict, mac_topic: str) -> di
     return {
         "play": {
             "platform": "button",
-            "name": None,
+            "name": "Play sound",
             "command_topic": f"{mac_topic}/play",
             "payload_press": "PLAY",
-            "device_class": "sound",
         },
         "ring_id": {
             "platform": "number",


### PR DESCRIPTION
Remove device class `sound` for the chime MQTT discovery config since that's not a valid device class (valid device classes are `identify`, `restart`, or `update` (or nothing). Before this change, the button would not appear in Home Assistant, and HA would return this error:
```
Error 'expected ButtonDeviceClass or one of 'identify', 'restart', 'update' for dictionary value @ data['device_class']' when processing MQTT discovery message topic: 'homeassistant/device/ws2m_sensor_DEADBEEF/config
...
```

Also change the default friendly name from `None` to "Play sound"